### PR TITLE
opusdec: fix crash with 64-bit VS builds

### DIFF
--- a/src/wave_out.c
+++ b/src/wave_out.c
@@ -71,7 +71,7 @@ Box ( const char* msg )
  */
 
 static void CALLBACK
-wave_callback ( HWAVE hWave, UINT uMsg, DWORD dwInstance, DWORD dwParam1, DWORD dwParam2 )
+wave_callback ( HWAVE hWave, UINT uMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2 )
 {
         (void) hWave;
         (void) dwInstance;


### PR DESCRIPTION
Fix suggested by mark4o.
Tested with 32 and 64-bit VS2015 and MinGW GCC 6.3.