### PR TITLE
win32: use same genversion script as opus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,8 +37,7 @@ EXTRA_DIST = Makefile.unix \
              win32/genversion.bat \
              win32/config.h \
              win32/unicode_support.h \
-             win32/unicode_support.c \
-             win32/version.h
+             win32/unicode_support.c
 
 dist_man_MANS = man/opusenc.1 man/opusdec.1 man/opusinfo.1
 

--- a/win32/genversion.bat
+++ b/win32/genversion.bat
@@ -1,17 +1,37 @@
 @echo off
 
-for /f %%v in ('git describe --tags --match "v*" --always') do set version=%%v
+setlocal enableextensions enabledelayedexpansion
 
-set version_out=#define %2 "%version%"
+for /f %%v in ('cd "%~dp0.." ^&^& git status ^>NUL 2^>NUL ^&^& git describe --tags --match "v*" --dirty 2^>NUL') do set version=%%v
 
-echo %version_out% > %1_temp
+if not "%version%"=="" set version=!version:~1! && goto :gotversion
 
-echo n | comp %1_temp %1 > NUL 2> NUL
+if exist "%~dp0..\package_version" goto :getversion
+
+echo Git cannot be found, nor can package_version. Generating unknown version.
+
+set version=unknown
+
+goto :gotversion
+ 
+:getversion
+
+for /f "delims== tokens=2" %%v in (%~dps0..\package_version) do set version=%%v
+set version=!version:"=!
+
+:gotversion
+
+set version=!version: =!
+set version_out=#define %~2 "%version%"
+
+echo %version_out%> "%~1_temp"
+
+echo n | comp "%~1_temp" "%~1" > NUL 2> NUL
 
 if not errorlevel 1 goto exit
 
-copy /y %1_temp %1
+copy /y "%~1_temp" "%~1"
 
 :exit
 
-del %1_temp
+del "%~1_temp"

--- a/win32/version.h
+++ b/win32/version.h
@@ -1,1 +1,0 @@
-#define PACKAGE_VERSION "v0.1.9-dev"


### PR DESCRIPTION
Like with opus, this generates an unknown version for git archives
(like the ones generated by GitHub). If you need a proper version
either use releases, a proper git repo or craft your own
package_version.