### PR TITLE
Adds --tracknumber argument to add track number to .opus files

### DIFF
--- a/man/opusenc.1
+++ b/man/opusenc.1
@@ -51,14 +51,14 @@ opusenc \- encode audio into the Opus format
 .B --title
 .I 'track title'
 ] [
-.B --tracknumber
-.I 'track number'
-] [
 .B --artist
 .I author
 ] [
 .B --album
 .I 'album title'
+] [
+.B --tracknumber
+.I 'track number'
 ] [
 .B --genre
 .I genre
@@ -202,9 +202,6 @@ Set maximum container delay in milliseconds (0-1000, default: 1000)
 .IP "--title title"
 Set the track title comment field to
 .I title
-.IP "--tracknumber N"
-Set the track number comment field to
-.I N
 .IP "--artist artist"
 Set the artist comment field to
 .I artist.
@@ -213,6 +210,9 @@ Note that some playback software does not display multiple artists gracefully.
 .IP "--album album"
 Set the album or collection title field to
 .I album
+.IP "--tracknumber N"
+Set the track number comment field to
+.I N
 .IP "--date YYYY-MM-DD"
 Set the date comment field to
 .I YYYY-MM-DD.

--- a/man/opusenc.1
+++ b/man/opusenc.1
@@ -51,6 +51,9 @@ opusenc \- encode audio into the Opus format
 .B --title
 .I 'track title'
 ] [
+.B --tracknumber
+.I 'track number'
+] [
 .B --artist
 .I author
 ] [
@@ -199,6 +202,9 @@ Set maximum container delay in milliseconds (0-1000, default: 1000)
 .IP "--title title"
 Set the track title comment field to
 .I title
+.IP "--tracknumber N"
+Set the track number comment field to
+.I N
 .IP "--artist artist"
 Set the artist comment field to
 .I artist.

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -156,7 +156,7 @@ static void usage(void)
   printf("                      (0-1000, default: 1000)\n");
   printf("\nMetadata options:\n");
   printf(" --title title      Set track title\n");
-  printf(" --tracknumber n    Set track title\n");
+  printf(" --tracknumber n    Set track number\n");
   printf(" --artist artist    Set artist or author, may be used multiple times\n");
   printf(" --album album      Set album or collection\n");
   printf(" --genre genre      Set genre, may be used multiple times\n");

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -156,6 +156,7 @@ static void usage(void)
   printf("                      (0-1000, default: 1000)\n");
   printf("\nMetadata options:\n");
   printf(" --title title      Set track title\n");
+  printf(" --tracknumber n    Set track title\n");
   printf(" --artist artist    Set artist or author, may be used multiple times\n");
   printf(" --album album      Set album or collection\n");
   printf(" --genre genre      Set genre, may be used multiple times\n");
@@ -384,6 +385,7 @@ int main(int argc, char **argv)
     {"comment", required_argument, NULL, 0},
     {"artist", required_argument, NULL, 0},
     {"title", required_argument, NULL, 0},
+	{"tracknumber", required_argument, NULL, 0},
     {"album", required_argument, NULL, 0},
     {"date", required_argument, NULL, 0},
     {"genre", required_argument, NULL, 0},
@@ -661,6 +663,7 @@ int main(int argc, char **argv)
           }
         } else if (strcmp(optname, "artist") == 0 ||
                    strcmp(optname, "title") == 0 ||
+			       strcmp(optname, "tracknumber") == 0 ||
                    strcmp(optname, "album") == 0 ||
                    strcmp(optname, "date") == 0 ||
                    strcmp(optname, "genre") == 0) {

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -156,9 +156,9 @@ static void usage(void)
   printf("                      (0-1000, default: 1000)\n");
   printf("\nMetadata options:\n");
   printf(" --title title      Set track title\n");
-  printf(" --tracknumber n    Set track number\n");
   printf(" --artist artist    Set artist or author, may be used multiple times\n");
   printf(" --album album      Set album or collection\n");
+  printf(" --tracknumber n    Set track number\n");
   printf(" --genre genre      Set genre, may be used multiple times\n");
   printf(" --date YYYY-MM-DD  Set date of track (YYYY, YYYY-MM, or YYYY-MM-DD)\n");
   printf(" --comment tag=val  Add the given string as an extra comment\n");
@@ -385,8 +385,8 @@ int main(int argc, char **argv)
     {"comment", required_argument, NULL, 0},
     {"artist", required_argument, NULL, 0},
     {"title", required_argument, NULL, 0},
-	{"tracknumber", required_argument, NULL, 0},
     {"album", required_argument, NULL, 0},
+    {"tracknumber", required_argument, NULL, 0},
     {"date", required_argument, NULL, 0},
     {"genre", required_argument, NULL, 0},
     {"picture", required_argument, NULL, 0},
@@ -663,8 +663,8 @@ int main(int argc, char **argv)
           }
         } else if (strcmp(optname, "artist") == 0 ||
                    strcmp(optname, "title") == 0 ||
-			       strcmp(optname, "tracknumber") == 0 ||
                    strcmp(optname, "album") == 0 ||
+                   strcmp(optname, "tracknumber") == 0 ||
                    strcmp(optname, "date") == 0 ||
                    strcmp(optname, "genre") == 0) {
           save_cmd=0;


### PR DESCRIPTION
Hi,

I added the --tracknumber argument to opusenc so that tools like Exact Audio Copy can pass the track number by using `--tracknumber %tracknr1%`, since it was missing from the command line options. Now it's possible to add track numbers with this PR. 