### PR TITLE
opusinfo: Add total playback samples to output (#40)

### DIFF
--- a/src/info_opus.c
+++ b/src/info_opus.c
@@ -263,15 +263,17 @@ void info_opus_end(stream_processor *stream)
     if(inf && inf->total_packets>0){
         int i, j;
         long minutes, seconds, milliseconds;
+        ogg_int64_t playback_samples;
         double time;
-        time = (inf->lastgranulepos-inf->firstgranule-inf->oh.preskip) / 48000.;
+        playback_samples = inf->lastgranulepos-inf->firstgranule-inf->oh.preskip;
+        time = playback_samples / 48000.;
         if(time<=0)time=0;
         minutes = (long)(time) / 60;
         seconds = (long)(time - minutes*60);
         milliseconds = (long)((time - minutes*60 - seconds)*1000);
         if(inf->lastgranulepos-inf->firstgranule<inf->oh.preskip)
            oi_error(_("\tERROR: stream %d has a negative duration: %" PRId64 "-%" PRId64 "-%d=%" PRId64 "\n"),stream->num,
-           inf->lastgranulepos,inf->firstgranule,inf->oh.preskip,inf->lastgranulepos-inf->firstgranule-inf->oh.preskip);
+           inf->lastgranulepos,inf->firstgranule,inf->oh.preskip,playback_samples);
         if((inf->total_samples-inf->last_page_duration)>(inf->lastgranulepos-inf->firstgranule))
            oi_error(_("\tERROR: stream %d has interior holes or more than one page of end trimming\n"),stream->num);
         if(inf->last_eos &&( (inf->last_page_duration-inf->last_packet_duration)>(inf->lastgranulepos-inf->lastlastgranulepos)))
@@ -309,6 +311,7 @@ void info_opus_end(stream_processor *stream)
         if(inf->total_pages)oi_info(_("\tPage duration: %8.1fms (max), %6.1fms (avg), %6.1fms (min)\n"),
             inf->max_page_duration/48.,inf->total_samples/(double)inf->total_pages/48.,inf->min_page_duration/48.);
         oi_info(_("\tTotal data length: %" PRId64 " bytes (overhead: %0.3g%%)\n"),inf->bytes,(double)inf->overhead_bytes/inf->bytes*100.);
+        oi_info(_("\tPlayback samples: %" PRId64 "\n"), playback_samples);
         oi_info(_("\tPlayback length: %ldm:%02ld.%03lds\n"), minutes, seconds, milliseconds);
         oi_info(_("\tAverage bitrate: %0.4g kbit/s, w/o overhead: %.04g kbit/s%s\n"),time<=0?0:inf->bytes*8/time/1000.0,
             time<=0?0:(inf->bytes-inf->overhead_bytes)*8/time/1000.0,


### PR DESCRIPTION
Adds "Playback samples" used to calculate the total duration in output.

```
$ opusinfo trimmed.opus
Processing file "trimmed.opus"...

New logical stream (#1, serial: 1c033e62): type opus
Encoded with libopus 1.1
User comments section follows...
  ENCODER=opusenc from opus-tools 0.1.9
  ENCODER_OPTIONS=--hard-cbr --bitrate 64
Opus stream 1:
  Pre-skip: 312
  Playback gain: 0 dB
  Channels: 2
  Original sample rate: 48000 Hz
  Packet duration:   20.0ms (max),   20.0ms (avg),   20.0ms (min)
  Page duration:   1000.0ms (max),  888.6ms (avg),  220.0ms (min)
  Total data length: 51101 bytes (overhead: 2.62%)
  Playback samples: 297910
  Playback length: 0m:06.206s
  Average bitrate: 65.87 kbit/s, w/o overhead: 64.14 kbit/s (hard-CBR)
Logical stream 1 ended
```