### PR TITLE
Opusdec needs libogg too

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ opusenc_MANS = man/opusenc.1
 opusdec_SOURCES = src/opus_header.c src/wav_io.c src/wave_out.c src/opusdec.c src/resample.c src/diag_range.c win32/unicode_support.c
 opusdec_CPPFLAGS = $(AM_CPPFLAGS) $(resampler_CPPFLAGS)
 opusdec_CFLAGS = $(AM_CFLAGS) $(OPUSURL_CFLAGS)
-opusdec_LDADD = $(OPUSURL_LIBS) $(OPUS_LIBS) $(LIBM)
+opusdec_LDADD = $(OPUSURL_LIBS) $(OPUS_LIBS) $(OGG_LIBS) $(LIBM)
 opusdec_MANS = man/opusdec.1
 
 opusinfo_SOURCES = src/opus_header.c src/opusinfo.c src/info_opus.c src/picture.c win32/unicode_support.c


### PR DESCRIPTION
ogg library was missing from Makefile.am, this fix is specially needed in systems without pkg-config.