### PR TITLE
opusenc: ignore SSND chunk length if reading from stdin

### DIFF
--- a/src/audio-in.c
+++ b/src/audio-in.c
@@ -402,7 +402,7 @@ int aiff_open(FILE *in, oe_enc_opt *opt, unsigned char *buf, int buflen)
         return 0; /* No SSND chunk -> no actual audio */
     }
 
-    if (len < 8)
+    if (len < 8 && in != stdin)
     {
         fprintf(stderr, _("ERROR: Corrupted SSND chunk in AIFF header\n"));
         return 0;


### PR DESCRIPTION
The input might be coming directly from an AIFF muxer, in which case
the size can't be knwon.