### PR TITLE
Implement --channels discrete format option

### DIFF
--- a/man/opusenc.1
+++ b/man/opusenc.1
@@ -312,12 +312,12 @@ Ignore the data length in Wave headers.
 The length will always be ignored when it is implausible (very small or very
 large), but some stdin usage may still need this option to avoid truncation.
 .TP
-.B --channels <ambix, individual>
+.B --channels <ambix, discrete>
 Override the format of the input channels.
 The "ambix" option indicates that the input is ambisonics using ACN channel
 ordering with SN3D normalization. All channels in a full ambisonics order must
 be included. A pair of non-diegetic stereo channels can be optionally placed
-after the ambisonics channels. The option "individual" forces uncoupled
+after the ambisonics channels. The option "discrete" forces uncoupled
 channels.
 .SS "Diagnostic options"
 .TP

--- a/man/opusenc.1
+++ b/man/opusenc.1
@@ -312,12 +312,13 @@ Ignore the data length in Wave headers.
 The length will always be ignored when it is implausible (very small or very
 large), but some stdin usage may still need this option to avoid truncation.
 .TP
-.B --channels <ambix>
+.B --channels <ambix, individual>
 Override the format of the input channels.
 The "ambix" option indicates that the input is ambisonics using ACN channel
 ordering with SN3D normalization. All channels in a full ambisonics order must
 be included. A pair of non-diegetic stereo channels can be optionally placed
-after the ambisonics channels.
+after the ambisonics channels. The option "individual" forces uncoupled
+channels.
 .SS "Diagnostic options"
 .TP
 .BI --serial " N"

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -18,6 +18,7 @@
 
 #define CHANNELS_FORMAT_DEFAULT  0
 #define CHANNELS_FORMAT_AMBIX    1
+#define CHANNELS_FORMAT_INDIVIDUAL 2
 
 typedef long (*audio_read_func)(void *src, float *buffer, int samples);
 

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -18,7 +18,7 @@
 
 #define CHANNELS_FORMAT_DEFAULT  0
 #define CHANNELS_FORMAT_AMBIX    1
-#define CHANNELS_FORMAT_INDIVIDUAL 2
+#define CHANNELS_FORMAT_DISCRETE 2
 
 typedef long (*audio_read_func)(void *src, float *buffer, int samples);
 

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -176,7 +176,7 @@ static void usage(void)
   printf(" --raw-chan n       Set number of channels for raw input (default: 2)\n");
   printf(" --raw-endianness n 1 for big endian, 0 for little (default: 0)\n");
   printf(" --ignorelength     Ignore the data length in Wave headers\n");
-  printf(" --channels         Override the format of the input channels (ambix, individual)\n");
+  printf(" --channels         Override the format of the input channels (ambix, discrete)\n");
   printf("\nDiagnostic options:\n");
   printf(" --serial n         Force use of a specific stream serial number\n");
   printf(" --save-range file  Save check values for every frame to a file\n");
@@ -637,11 +637,11 @@ int main(int argc, char **argv)
         } else if (strcmp(optname, "channels")==0) {
           if (strcmp(optarg, "ambix")==0) {
             inopt.channels_format=CHANNELS_FORMAT_AMBIX;
-          } else if (strcmp(optarg, "individual")==0) {
-            inopt.channels_format=CHANNELS_FORMAT_INDIVIDUAL;
+          } else if (strcmp(optarg, "discrete")==0) {
+            inopt.channels_format=CHANNELS_FORMAT_DISCRETE;
           } else {
             fatal("Invalid input format: %s\n"
-              "--channels only supports 'ambix' or 'individual'\n",
+              "--channels only supports 'ambix' or 'discrete'\n",
               optarg);
           }
         } else if (strcmp(optname, "serial")==0) {
@@ -883,7 +883,7 @@ int main(int argc, char **argv)
     fatal("Error: downmixing is currently unimplemented for ambisonics input.\n");
   }
 
-  if (downmix>0&&inopt.channels_format==CHANNELS_FORMAT_INDIVIDUAL) {
+  if (downmix>0&&inopt.channels_format==CHANNELS_FORMAT_DISCRETE) {
     /*Downmix of uncoupled channels not specified.*/
     fatal("Error: downmixing is currently unimplemented for independent input.\n");
   }
@@ -911,7 +911,7 @@ int main(int argc, char **argv)
       (including the non-diegetic stereo track). For other orders with no
       demixing matrices currently available, use channel mapping 2.*/
     mapping_family=(chan>=4&&chan<=18)?3:2;
-  } else if (inopt.channels_format==CHANNELS_FORMAT_INDIVIDUAL) {
+  } else if (inopt.channels_format==CHANNELS_FORMAT_DISCRETE) {
     mapping_family=255;
   } else {
     mapping_family=chan>8?255:chan>2;

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -176,7 +176,7 @@ static void usage(void)
   printf(" --raw-chan n       Set number of channels for raw input (default: 2)\n");
   printf(" --raw-endianness n 1 for big endian, 0 for little (default: 0)\n");
   printf(" --ignorelength     Ignore the data length in Wave headers\n");
-  printf(" --channels <ambix> Override the format of the input channels\n");
+  printf(" --channels         Override the format of the input channels (ambix, individual)\n");
   printf("\nDiagnostic options:\n");
   printf(" --serial n         Force use of a specific stream serial number\n");
   printf(" --save-range file  Save check values for every frame to a file\n");
@@ -637,9 +637,11 @@ int main(int argc, char **argv)
         } else if (strcmp(optname, "channels")==0) {
           if (strcmp(optarg, "ambix")==0) {
             inopt.channels_format=CHANNELS_FORMAT_AMBIX;
+          } else if (strcmp(optarg, "individual")==0) {
+            inopt.channels_format=CHANNELS_FORMAT_INDIVIDUAL;
           } else {
             fatal("Invalid input format: %s\n"
-              "--channels only supports 'ambix'\n",
+              "--channels only supports 'ambix' or 'individual'\n",
               optarg);
           }
         } else if (strcmp(optname, "serial")==0) {
@@ -881,6 +883,11 @@ int main(int argc, char **argv)
     fatal("Error: downmixing is currently unimplemented for ambisonics input.\n");
   }
 
+  if (downmix>0&&inopt.channels_format==CHANNELS_FORMAT_INDIVIDUAL) {
+    /*Downmix of uncoupled channels not specified.*/
+    fatal("Error: downmixing is currently unimplemented for independent input.\n");
+  }
+
   if (inopt.channels_format==CHANNELS_FORMAT_DEFAULT) {
     if (downmix==0&&inopt.channels>2&&bitrate>0&&bitrate<(16000*inopt.channels)) {
       if (!quiet) fprintf(stderr,"Notice: Surround bitrate less than 16 kbit/s per channel, downmixing.\n");
@@ -904,6 +911,8 @@ int main(int argc, char **argv)
       (including the non-diegetic stereo track). For other orders with no
       demixing matrices currently available, use channel mapping 2.*/
     mapping_family=(chan>=4&&chan<=18)?3:2;
+  } else if (inopt.channels_format==CHANNELS_FORMAT_INDIVIDUAL) {
+    mapping_family=255;
   } else {
     mapping_family=chan>8?255:chan>2;
   }


### PR DESCRIPTION
This implements an option to specify the channel format as _individual_, providing an alternative to the default and ambix format.
Currently, input with up to 8 channels is interpreted as surround input triggering coupled channels.
This behavior is, however, detrimental when using individual / discrete streams that should not be coded as stereo coupled, such as e.g. microphone array signals.
The proposed format uses the channel mapping family 255, which is explicitly defined for such scenarios.