### PR TITLE
Fix flac_id to 4 to support small FLAC files

### DIFF
--- a/src/audio-in.c
+++ b/src/audio-in.c
@@ -114,7 +114,7 @@
 input_format formats[] = {
     {wav_id, 12, wav_open, wav_close, "WAV", N_("WAV file reader")},
     {aiff_id, 12, aiff_open, wav_close, "AIFF", N_("AIFF/AIFC file reader")},
-    {flac_id,     0x10000, flac_open, flac_close, "FLAC", N_("FLAC file reader")},
+    {flac_id,     4, flac_open, flac_close, "FLAC", N_("FLAC file reader")},
     {oggflac_id, 33, flac_open, flac_close, "Ogg FLAC", N_("Ogg FLAC file reader")},
     {NULL, 0, NULL, NULL, NULL, NULL}
 };


### PR DESCRIPTION
This fixes an issue where small FLAC files were not correctly detected due to an incorrect flac_id value.
Fixes #78