### PR TITLE
Add ReplayGain handling modes and automatic filenames to opusenc

### DIFF
--- a/src/encoder.h
+++ b/src/encoder.h
@@ -20,6 +20,11 @@
 #define CHANNELS_FORMAT_AMBIX    1
 #define CHANNELS_FORMAT_DISCRETE 2
 
+#define RG_DONT_COPY           0
+#define RG_CONVERT_TO_R128     1
+#define RG_COPY                2
+#define RG_COPY_TO_OUTPUT_GAIN 3
+
 typedef int (*audio_read_func)(void *src, float *buffer, int samples);
 
 typedef struct
@@ -39,6 +44,7 @@ typedef struct
     OggOpusComments *comments;
     int copy_comments;
     int copy_pictures;
+    int copy_rgain;
 } oe_enc_opt;
 
 void setup_scaler(oe_enc_opt *opt, float scale);

--- a/src/flac.c
+++ b/src/flac.c
@@ -183,20 +183,29 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
           ope_comments_add_string(inopt->comments,entry);
         }
         setlocale(LC_NUMERIC,saved_locale);
-        /*Set the header gain to the album gain after converting to the R128
-          reference level (-23 LUFS).*/
-        if(saw_album_gain){
-          gain=256*(album_gain+(-23-reference_loudness))+0.5;
-          inopt->gain=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
+        /*Set the header gain to 0.*/
+        if(saw_album_gain || saw_track_gain){
+        	inopt->gain = 0;
         }
+          
         /*If there was a track gain, then add an equivalent R128 tag for that.*/
         if(saw_track_gain){
           char track_gain_buf[7];
           int track_gain_val;
-          gain=256*(track_gain-album_gain)+0.5;
+          gain=256*(track_gain+(-23-reference_loudness));
           track_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
           sprintf(track_gain_buf,"%i",track_gain_val);
           ope_comments_add(inopt->comments, "R128_TRACK_GAIN",track_gain_buf);
+        }
+        /*Now set the album gain to the volume difference.*/
+        if(saw_album_gain){
+          char album_gain_buf[7];
+          int album_gain_val;
+          gain=256*(album_gain+(-23-reference_loudness));
+          //inopt->gain = gain<-32768 ? -32768 : gain<32767 ? (int)floor(gain) : 32767;
+          album_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
+          sprintf(album_gain_buf,"%i",album_gain_val);
+          ope_comments_add(inopt->comments, "R128_ALBUM_GAIN",album_gain_buf);
         }
       }
       break;

--- a/src/flac.c
+++ b/src/flac.c
@@ -134,45 +134,47 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
           char *end;
           entry=(char *)comments[i].entry;
           if(!entry)continue;
-          /*Check for ReplayGain tags.
+          /*Check for ReplayGain tags if using any of the R128 conversion modes.
             Parse the ones we have R128 equivalents for, and skip the others.*/
-          if(tagcompare(entry,"REPLAYGAIN_REFERENCE_LOUDNESS=",30)==0){
-            /*Reference loundness may be in dB SPL (positive) or
-              LUFS (negative).  The 89 dB SPL reference is considered
-              to be the same loudness as -18 LUFS.*/
-            gain=strtod(entry+30,&end);
-            if(end<=entry+30){
-              fprintf(stderr,_("WARNING: Invalid ReplayGain tag: %s\n"),entry);
+          if(inopt->copy_rgain != RG_COPY){
+            if(tagcompare(entry,"REPLAYGAIN_REFERENCE_LOUDNESS=",30)==0){
+              /*Reference loundness may be in dB SPL (positive) or
+                LUFS (negative).  The 89 dB SPL reference is considered
+                to be the same loudness as -18 LUFS.*/
+              gain=strtod(entry+30,&end);
+              if(end<=entry+30){
+                fprintf(stderr,_("WARNING: Invalid ReplayGain tag: %s\n"),entry);
+              }
+              else if (gain<0) reference_loudness=gain;
+              else reference_loudness=gain-89-18;
+              continue;
             }
-            else if (gain<0) reference_loudness=gain;
-            else reference_loudness=gain-89-18;
-            continue;
-          }
-          if(tagcompare(entry,"REPLAYGAIN_ALBUM_GAIN=",22)==0){
-            gain=strtod(entry+22,&end);
-            if(end<=entry+22){
-              fprintf(stderr,_("WARNING: Invalid ReplayGain tag: %s\n"),entry);
+            if(tagcompare(entry,"REPLAYGAIN_ALBUM_GAIN=",22)==0){
+              gain=strtod(entry+22,&end);
+              if(end<=entry+22){
+                fprintf(stderr,_("WARNING: Invalid ReplayGain tag: %s\n"),entry);
+              }
+              else{
+                album_gain=gain;
+                saw_album_gain=1;
+              }
+              continue;
             }
-            else{
-              album_gain=gain;
-              saw_album_gain=1;
+            if(tagcompare(entry,"REPLAYGAIN_TRACK_GAIN=",22)==0){
+              gain=strtod(entry+22,&end);
+              if(end<entry+22){
+                fprintf(stderr,_("WARNING: Invalid ReplayGain tag: %s\n"),entry);
+              }
+              else{
+                track_gain=gain;
+                saw_track_gain=1;
+              }
+              continue;
             }
-            continue;
-          }
-          if(tagcompare(entry,"REPLAYGAIN_TRACK_GAIN=",22)==0){
-            gain=strtod(entry+22,&end);
-            if(end<entry+22){
-              fprintf(stderr,_("WARNING: Invalid ReplayGain tag: %s\n"),entry);
+            if(tagcompare(entry,"REPLAYGAIN_ALBUM_PEAK=",22)==0
+               ||tagcompare(entry,"REPLAYGAIN_TRACK_PEAK=",22)==0){
+              continue;
             }
-            else{
-              track_gain=gain;
-              saw_track_gain=1;
-            }
-            continue;
-          }
-          if(tagcompare(entry,"REPLAYGAIN_ALBUM_PEAK=",22)==0
-             ||tagcompare(entry,"REPLAYGAIN_TRACK_PEAK=",22)==0){
-            continue;
           }
           if(!strchr(entry,'=')){
             fprintf(stderr,_("WARNING: Invalid comment: %s\n"),entry);
@@ -183,29 +185,49 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
           ope_comments_add_string(inopt->comments,entry);
         }
         setlocale(LC_NUMERIC,saved_locale);
-        /*Set the header gain to 0.*/
-        if(saw_album_gain || saw_track_gain){
-        	inopt->gain = 0;
-        }
-          
-        /*If there was a track gain, then add an equivalent R128 tag for that.*/
-        if(saw_track_gain){
-          char track_gain_buf[7];
-          int track_gain_val;
-          gain=256*(track_gain+(-23-reference_loudness));
-          track_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
-          sprintf(track_gain_buf,"%i",track_gain_val);
-          ope_comments_add(inopt->comments, "R128_TRACK_GAIN",track_gain_buf);
-        }
-        /*Now set the album gain to the volume difference.*/
-        if(saw_album_gain){
-          char album_gain_buf[7];
-          int album_gain_val;
-          gain=256*(album_gain+(-23-reference_loudness));
-          //inopt->gain = gain<-32768 ? -32768 : gain<32767 ? (int)floor(gain) : 32767;
-          album_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
-          sprintf(album_gain_buf,"%i",album_gain_val);
-          ope_comments_add(inopt->comments, "R128_ALBUM_GAIN",album_gain_buf);
+
+        switch(inopt->copy_rgain){
+          case RG_CONVERT_TO_R128:
+            /*If there was a track gain, then add an equivalent R128 tag for that.*/
+            if(saw_track_gain){
+              char track_gain_buf[7];
+              int track_gain_val;
+              gain=256*(track_gain+(-23-reference_loudness));
+              track_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
+              sprintf(track_gain_buf,"%i",track_gain_val);
+              ope_comments_add(inopt->comments, "R128_TRACK_GAIN",track_gain_buf);
+            }
+            /*Now do the album gain too.*/
+            if(saw_album_gain){
+              char album_gain_buf[7];
+              int album_gain_val;
+              gain=256*(album_gain+(-23-reference_loudness));
+              album_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
+              sprintf(album_gain_buf,"%i",album_gain_val);
+              ope_comments_add(inopt->comments, "R128_ALBUM_GAIN",album_gain_buf);
+            }
+            break;
+          case RG_COPY_TO_OUTPUT_GAIN:
+            /*Here we want the more common tag in the header.*/
+            if(saw_track_gain){
+              gain=inopt->gain+(256*(track_gain+(-23-reference_loudness)));
+              inopt->gain=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
+              
+              /*Blank track gain here as to not confuse any players.*/
+              char gain_buf[7];
+              sprintf(gain_buf,"%i",0);
+              ope_comments_add(inopt->comments, "R128_TRACK_GAIN",gain_buf);
+            }
+            /*Those who care can use the album gain tag.*/
+            if(saw_album_gain){
+              char album_gain_buf[7];
+              int album_gain_val;
+              gain=256*(album_gain-track_gain);
+              album_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
+              sprintf(album_gain_buf,"%i",album_gain_val);
+              ope_comments_add(inopt->comments, "R128_ALBUM_GAIN",album_gain_buf);
+            }
+            break;
         }
       }
       break;

--- a/src/flac.c
+++ b/src/flac.c
@@ -211,15 +211,16 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
             break;
           case RG_COPY_TO_OUTPUT_GAIN:
             /*Here we want the more common tag in the header.*/
-            if(saw_track_gain){
-              gain=inopt->gain+(256*track_gain);
-              inopt->gain=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
-              
-              /*Since it is a lot more likely for a player to try to correct
+            
+            /*Since it is a lot more likely for a player to try to correct
               the R128_GAIN_* value instead of OpusHead gain, and since the
               header gain does not have a set target like R128 does in the
               Opus standard, we use ReplayGain directly in the header and
-              correct with R128_GAIN tags.*/
+              adjust with R128_GAIN tags. This hack works perfectly in AIMP
+              and Auxio.*/
+            if(saw_track_gain){
+              gain=inopt->gain+(256*track_gain);
+              inopt->gain=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
               char gain_buf[7];
               sprintf(gain_buf,"%i",(int)floor(256*loudness_correction));
               ope_comments_add(inopt->comments, "R128_TRACK_GAIN",gain_buf);

--- a/src/flac.c
+++ b/src/flac.c
@@ -185,14 +185,16 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
           ope_comments_add_string(inopt->comments,entry);
         }
         setlocale(LC_NUMERIC,saved_locale);
-
+        
+        double loudness_correction = -23-reference_loudness;
+        
         switch(inopt->copy_rgain){
           case RG_CONVERT_TO_R128:
             /*If there was a track gain, then add an equivalent R128 tag for that.*/
             if(saw_track_gain){
               char track_gain_buf[7];
               int track_gain_val;
-              gain=256*(track_gain+(-23-reference_loudness));
+              gain=256*(track_gain+loudness_correction);
               track_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
               sprintf(track_gain_buf,"%i",track_gain_val);
               ope_comments_add(inopt->comments, "R128_TRACK_GAIN",track_gain_buf);
@@ -201,7 +203,7 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
             if(saw_album_gain){
               char album_gain_buf[7];
               int album_gain_val;
-              gain=256*(album_gain+(-23-reference_loudness));
+              gain=256*(album_gain+loudness_correction);
               album_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
               sprintf(album_gain_buf,"%i",album_gain_val);
               ope_comments_add(inopt->comments, "R128_ALBUM_GAIN",album_gain_buf);
@@ -210,19 +212,23 @@ static void metadata_callback(const FLAC__StreamDecoder *decoder,
           case RG_COPY_TO_OUTPUT_GAIN:
             /*Here we want the more common tag in the header.*/
             if(saw_track_gain){
-              gain=inopt->gain+(256*(track_gain+(-23-reference_loudness)));
+              gain=inopt->gain+(256*track_gain);
               inopt->gain=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
               
-              /*Blank track gain here as to not confuse any players.*/
+              /*Since it is a lot more likely for a player to try to correct
+              the R128_GAIN_* value instead of OpusHead gain, and since the
+              header gain does not have a set target like R128 does in the
+              Opus standard, we use ReplayGain directly in the header and
+              correct with R128_GAIN tags.*/
               char gain_buf[7];
-              sprintf(gain_buf,"%i",0);
+              sprintf(gain_buf,"%i",(int)floor(256*loudness_correction));
               ope_comments_add(inopt->comments, "R128_TRACK_GAIN",gain_buf);
             }
             /*Those who care can use the album gain tag.*/
             if(saw_album_gain){
               char album_gain_buf[7];
               int album_gain_val;
-              gain=256*(album_gain-track_gain);
+              gain=256*((album_gain-track_gain)+loudness_correction);
               album_gain_val=gain<-32768?-32768:gain<32767?(int)floor(gain):32767;
               sprintf(album_gain_buf,"%i",album_gain_val);
               ope_comments_add(inopt->comments, "R128_ALBUM_GAIN",album_gain_buf);

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -128,16 +128,16 @@ static void usage(void)
   printf("The input format can be Wave, AIFF, or raw PCM.\n");
 #endif
   printf("\ninput_file can be:\n");
-  printf("  filename.wav      file\n");
-  printf("  -                 stdin\n");
+  printf("  filename.wav       file\n");
+  printf("  -                  stdin\n");
   printf("\noutput_file can be:\n");
-  printf("  filename.opus     compressed file\n");
-  printf("  -                 stdout\n");
+  printf("  filename.opus      compressed file\n");
+  printf("  -                  stdout\n");
   printf("\nGeneral options:\n");
-  printf(" -h, --help         Show this help\n");
-  printf(" -V, --version      Show version information\n");
-  printf(" --help-picture     Show help on attaching album art\n");
-  printf(" --quiet            Enable quiet mode\n");
+  printf(" -h, --help          Show this help\n");
+  printf(" -V, --version       Show version information\n");
+  printf(" --help-picture      Show help on attaching album art\n");
+  printf(" --quiet             Enable quiet mode\n");
   printf("\nEncoding options:\n");
   printf(" --bitrate n.nnn    Set target bitrate in kbit/s (6-256/channel)\n");
   printf(" --vbr              Use variable bitrate encoding (default)\n");
@@ -156,39 +156,41 @@ static void usage(void)
   printf(" --downmix-mono     Downmix to mono\n");
   printf(" --downmix-stereo   Downmix to stereo (if >2 channels)\n");
 #ifdef OPUS_SET_PHASE_INVERSION_DISABLED_REQUEST
-  printf(" --no-phase-inv     Disable use of phase inversion for intensity stereo\n");
+  printf(" --no-phase-inv      Disable use of phase inversion for intensity stereo\n");
 #endif
-  printf(" --max-delay n      Set maximum container delay in milliseconds\n");
-  printf("                      (0-1000, default: 1000)\n");
+  printf(" --max-delay n       Set maximum container delay in milliseconds\n");
+  printf("                       (0-1000, default: 1000)\n");
   printf("\nMetadata options:\n");
-  printf(" --title title      Set track title\n");
-  printf(" --artist artist    Set artist or author, may be used multiple times\n");
-  printf(" --album album      Set album or collection\n");
-  printf(" --genre genre      Set genre, may be used multiple times\n");
-  printf(" --date YYYY-MM-DD  Set date of track (YYYY, YYYY-MM, or YYYY-MM-DD)\n");
-  printf(" --tracknumber n    Set track number\n");
-  printf(" --comment tag=val  Add the given string as an extra comment\n");
-  printf("                      This may be used multiple times\n");
-  printf(" --picture file     Attach album art (see --help-picture)\n");
-  printf("                      This may be used multiple times\n");
-  printf(" --padding n        Reserve n extra bytes for metadata (default: 512)\n");
-  printf(" --discard-comments Don't keep metadata when transcoding\n");
-  printf(" --discard-pictures Don't keep pictures when transcoding\n");
+  printf(" --title title       Set track title\n");
+  printf(" --artist artist     Set artist or author, may be used multiple times\n");
+  printf(" --album album       Set album or collection\n");
+  printf(" --genre genre       Set genre, may be used multiple times\n");
+  printf(" --date YYYY-MM-DD   Set date of track (YYYY, YYYY-MM, or YYYY-MM-DD)\n");
+  printf(" --tracknumber n     Set track number\n");
+  printf(" --comment tag=val   Add the given string as an extra comment\n");
+  printf("                       This may be used multiple times\n");
+  printf(" --picture file      Attach album art (see --help-picture)\n");
+  printf("                       This may be used multiple times\n");
+  printf(" --padding n         Reserve n extra bytes for metadata (default: 512)\n");
+  printf(" --discard-comments  Don't keep metadata when transcoding\n");
+  printf(" --discard-pictures  Don't keep pictures when transcoding\n");
+  printf(" --replaygain-mode n Choose behavior of ReplayGain conversion\n");
+  printf("                       (0: ignore, 1: convert to R128, 2: copy, 3: track gain in header)\n");
   printf("\nInput options:\n");
-  printf(" --raw              Interpret input as raw PCM data without headers\n");
-  printf(" --raw-float        Interpret input as raw float data without headers\n");
-  printf(" --raw-bits n       Set bits/sample for raw input (default: 16; 32 for float)\n");
-  printf(" --raw-rate n       Set sampling rate for raw input (default: 48000)\n");
-  printf(" --raw-chan n       Set number of channels for raw input (default: 2)\n");
-  printf(" --raw-endianness n 1 for big endian, 0 for little (default: 0)\n");
-  printf(" --ignorelength     Ignore the data length in Wave headers\n");
-  printf(" --channels fmt     Override the format of the input channels (ambix, discrete)\n");
+  printf(" --raw               Interpret input as raw PCM data without headers\n");
+  printf(" --raw-float         Interpret input as raw float data without headers\n");
+  printf(" --raw-bits n        Set bits/sample for raw input (default: 16; 32 for float)\n");
+  printf(" --raw-rate n        Set sampling rate for raw input (default: 48000)\n");
+  printf(" --raw-chan n        Set number of channels for raw input (default: 2)\n");
+  printf(" --raw-endianness n  1 for big endian, 0 for little (default: 0)\n");
+  printf(" --ignorelength      Ignore the data length in Wave headers\n");
+  printf(" --channels fmt      Override the format of the input channels (ambix, discrete)\n");
   printf("\nDiagnostic options:\n");
-  printf(" --serial n         Force use of a specific stream serial number\n");
-  printf(" --save-range file  Save check values for every frame to a file\n");
-  printf(" --set-ctl-int x=y  Pass the encoder control x with value y (advanced)\n");
-  printf("                      Preface with s: to direct the ctl to multistream s\n");
-  printf("                      This may be used multiple times\n");
+  printf(" --serial n          Force use of a specific stream serial number\n");
+  printf(" --save-range file   Save check values for every frame to a file\n");
+  printf(" --set-ctl-int x=y   Pass the encoder control x with value y (advanced)\n");
+  printf("                       Preface with s: to direct the ctl to multistream s\n");
+  printf("                       This may be used multiple times\n");
 }
 
 static void help_picture(void)
@@ -437,6 +439,7 @@ int main(int argc, char **argv)
     {"padding", required_argument, NULL, 0},
     {"discard-comments", no_argument, NULL, 0},
     {"discard-pictures", no_argument, NULL, 0},
+    {"replaygain-mode", required_argument, NULL, 0},
     {0, 0, 0, 0}
   };
   int i, ret;
@@ -516,6 +519,7 @@ int main(int argc, char **argv)
   inopt.ignorelength=0;
   inopt.copy_comments=1;
   inopt.copy_pictures=1;
+  inopt.copy_rgain=RG_CONVERT_TO_R128;
 
   start_time = time(NULL);
   srand((((unsigned)getpid()&65535)<<15)^(unsigned)start_time);
@@ -829,6 +833,15 @@ int main(int argc, char **argv)
           save_cmd=0;
         } else if (strcmp(optname, "discard-pictures")==0) {
           inopt.copy_pictures=0;
+          save_cmd=0;
+        } else if (strcmp(optname, "replaygain-mode")==0) {
+          int val = atoi(optarg);
+          if (val < 0 || val > 3) {
+            fatal("Invalid replaygain-mode: %s\n"
+              "Mode must correspond to modes 0-3.\n",
+              optarg);
+          }
+          inopt.copy_rgain = val;
           save_cmd=0;
         }
         /*Options whose arguments would leak file paths or just end up as

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -389,6 +389,39 @@ static const char *channels_format_name(int channels_format, int channels)
   return "discrete";
 }
 
+/* this will Mega Turbo break with weird filenames.
+   fix later. */
+char *ope_gen_outfile(char *inFile)
+{
+  char *start, *end, *outfilename;
+  
+  /*static const char *file_ext[3] =
+  {
+    ".wav", ".flac", ".ogg"
+  };
+
+  for(int i = 0; i < sizeof(file_ext); i++)
+  {
+    start=inFile;
+    end=strpbrk(inFile,file_ext[i]);
+    if(end) break;
+  }
+
+  if(end == NULL)
+    end = start+strlen(inFile)+1;*/
+
+  start=inFile;
+  end=strrchr(inFile, '.');
+  end=end?end:start+strlen(inFile)+1;
+    
+  outfilename=malloc(end-start+5);
+  strncpy(outfilename,start,end-start);
+  outfilename[end-start]=0;
+  strcat(outfilename,".opus");
+  printf("Output file: %s\n", outfilename, start, end);
+  return outfilename;
+}
+
 int main(int argc, char **argv)
 {
   static const input_format raw_format =
@@ -889,12 +922,23 @@ int main(int argc, char **argv)
     fatal("Invalid bit-depth:\n"
       "--raw-bits must be 32 for float sample format\n");
   }
-  if (argc_utf8-optind!=2) {
+
+  int argcnt = argc_utf8 - optind;
+  if (argcnt < 1) {
+    usage();
+    exit(1);
+  } 
+  inFile=argv_utf8[optind]; 
+  if(argcnt > 1) {
+    outFile=argv_utf8[optind+1];
+  }
+  else if(inFile) {
+    outFile=ope_gen_outfile(inFile);
+  }
+  else {
     usage();
     exit(1);
   }
-  inFile=argv_utf8[optind];
-  outFile=argv_utf8[optind+1];
 
   if (cline_size > 0) {
     ret = ope_comments_add(inopt.comments, "ENCODER_OPTIONS", ENCODER_string);

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -389,36 +389,20 @@ static const char *channels_format_name(int channels_format, int channels)
   return "discrete";
 }
 
-/* this will Mega Turbo break with weird filenames.
-   fix later. */
+// [jdsc] might break in edge cases, but should work well
 char *ope_gen_outfile(char *inFile)
 {
   char *start, *end, *outfilename;
-  
-  /*static const char *file_ext[3] =
-  {
-    ".wav", ".flac", ".ogg"
-  };
-
-  for(int i = 0; i < sizeof(file_ext); i++)
-  {
-    start=inFile;
-    end=strpbrk(inFile,file_ext[i]);
-    if(end) break;
-  }
-
-  if(end == NULL)
-    end = start+strlen(inFile)+1;*/
 
   start=inFile;
   end=strrchr(inFile, '.');
-  end=end?end:start+strlen(inFile)+1;
+  end=(end==NULL||end==start)?end:start+strlen(inFile)+1;
     
-  outfilename=malloc(end-start+5);
+  outfilename=malloc(end-start+6);
   strncpy(outfilename,start,end-start);
-  outfilename[end-start]=0;
+  outfilename[end-start]='\0';
   strcat(outfilename,".opus");
-  printf("Output file: %s\n", outfilename, start, end);
+  printf("Output file: %s\n", outfilename);
   return outfilename;
 }
 

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -394,9 +394,21 @@ char *ope_gen_outfile(char *inFile)
 {
   char *start, *end, *outfilename;
 
-  start=inFile;
+  start=strrchr(inFile, '/');
+
+  #if defined WIN32 || defined _WIN32 || defined __MINGW32__
+  {
+    char *backslash;
+    backslash=strrchr(inFile, '\\');
+    if(backslash!=NULL&&(start==NULL||backslash>start))
+      start=backslash;
+  }
+  #endif
+  
+  start=(start==NULL)?inFile:start+1;
+  
   end=strrchr(inFile, '.');
-  end=(end==NULL||end==start)?end:start+strlen(inFile)+1;
+  end=(end==NULL||end==start)?start+strlen(inFile):end;
     
   outfilename=malloc(end-start+6);
   strncpy(outfilename,start,end-start);

--- a/src/opusenc.c
+++ b/src/opusenc.c
@@ -407,7 +407,7 @@ char *ope_gen_outfile(char *inFile)
   
   start=(start==NULL)?inFile:start+1;
   
-  end=strrchr(inFile, '.');
+  end=strrchr(start, '.');
   end=(end==NULL||end==start)?start+strlen(inFile):end;
     
   outfilename=malloc(end-start+6);


### PR DESCRIPTION
Adds a --replaygain-mode argument that allows tweaking the handling of RG tags:
```
--replaygain-mode n Choose behavior of ReplayGain conversion
                       (0: ignore, 1: convert to R128, 2: copy, 3: track gain in header)
```
0 will completely scrap all ReplayGain tags;
1 will convert it to the EBU R128 standard, and yes it does account for the target difference;
2 just copies the values directly, not ideal but some players don't know what an "Arr One Twenty-Eight" is;
3 puts the track gain directly in the header and does some stuff to correct for the volume difference in players that DO support R128, since the decoder handles header gain this works on everything.

Also added automatic output filenames, to speed up conversion:
```
> opusenc --bitrate 96 "Gojira - Terra Inc..flac"
Output file: Gojira - Terra Inc..opus
Encoding using libopus unknown (audio)
-----------------------------------------------------
   Input: FLAC, 44.1 kHz, 2 channels, stereo
  Output: Opus, 2 channels (2 coupled), stereo
          20ms packets, 96 kbit/s VBR
 Preskip: 312

Encoding complete
-----------------------------------------------------
       Encoded: 2 minutes and 55.9 seconds
       Runtime: 13 seconds
                (13.53x realtime)
         Wrote: 2356617 bytes, 8795 packets, 179 pages
       Bitrate: 102.852 kbit/s (without overhead)
 Instant rates: 71.6 to 191.2 kbit/s
                (179 to 478 bytes per packet)
      Overhead: 4.04% (container+metadata)

> file "Gojira - Terra Inc..opus"
Gojira - Terra Inc..opus: Ogg data, Opus audio, version 0.1, stereo, 44100 Hz (Input Sample Rate)
```
It strips the path and replaces the extension, pretty simple. The option of typing it manually is still there if needed.